### PR TITLE
Switch scratchpad WYSIWYG to TipTap

### DIFF
--- a/packages/excalidraw/wysiwyg/scratchpadWysiwyg.tsx
+++ b/packages/excalidraw/wysiwyg/scratchpadWysiwyg.tsx
@@ -1,3 +1,5 @@
+import React, { useEffect } from "react";
+import { createRoot } from "react-dom/client";
 import { EditorContent, JSONContent, useEditor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import TextStyle from "@tiptap/extension-text-style";
@@ -230,22 +232,6 @@ export const scratchpadWysiwyg = ({
         }
       }
       const [viewportX, viewportY] = getViewportCoords(coordX, coordY);
-      const initialSelectionStart = editable.selectionStart;
-      const initialSelectionEnd = editable.selectionEnd;
-      const initialLength = editable.value.length;
-
-      // restore cursor position after value updated so it doesn't
-      // go to the end of text when container auto expanded
-      if (
-        initialSelectionStart === initialSelectionEnd &&
-        initialSelectionEnd !== initialLength
-      ) {
-        // get diff between length and selection end and shift
-        // the cursor by "diff" times to position correctly
-        const diff = initialLength - initialSelectionEnd;
-        editable.selectionStart = editable.value.length - diff;
-        editable.selectionEnd = editable.value.length - diff;
-      }
 
       if (!container) {
         maxWidth = (appState.width - 8 - viewportX) / appState.zoom.value;
@@ -296,15 +282,11 @@ export const scratchpadWysiwyg = ({
     }
   };
 
-  const editable = document.createElement("textarea");
-  // const editable = document.createElement("div");
-  // editable.classList.add("excalidraw-wysiwyg");
+  const editable = document.createElement("div");
 
   editable.dir = "auto";
   editable.tabIndex = 0;
   editable.dataset.type = "wysiwyg";
-  // prevent line wrapping on Safari
-  editable.wrap = "off";
   editable.classList.add("excalidraw-wysiwyg");
 
   let whiteSpace = "pre";
@@ -334,56 +316,41 @@ export const scratchpadWysiwyg = ({
     overflowWrap: "break-word",
     boxSizing: "content-box",
   });
-  editable.value = element.originalText;
   updateWysiwygStyle();
 
-  if (onChange) {
-    editable.onpaste = async (event) => {
-      const clipboardData = await parseClipboard(event, true);
-      if (!clipboardData.text) {
-        return;
-      }
-      const data = normalizeText(clipboardData.text);
-      if (!data) {
-        return;
-      }
-      const container = getContainerElement(
-        element,
-        app.scene.getNonDeletedElementsMap(),
-      );
+  let editor: ReturnType<typeof useEditor> | null = null;
+  let prevDoc = element.tiptapDoc;
+  const changeHistory = [...(element.changeHistory || [])];
 
-      const font = getFontString({
-        fontSize: app.state.currentItemFontSize,
-        fontFamily: app.state.currentItemFontFamily,
-      });
-      if (container) {
-        const boundTextElement = getBoundTextElement(
-          container,
-          app.scene.getNonDeletedElementsMap(),
-        );
-        const wrappedText = wrapText(
-          `${editable.value}${data}`,
-          font,
-          getBoundTextMaxWidth(container, boundTextElement),
-        );
-        const width = getTextWidth(wrappedText, font);
-        editable.style.width = `${width}px`;
-      }
-    };
+  const ScratchpadEditor = () => {
+    const ed = useEditor({
+      extensions: [StarterKit, TextStyle, Color],
+      content: prevDoc,
+      onUpdate: ({ editor: ed }) => {
+        const doc = ed.getJSON();
+        if (onChange) {
+          onChange(doc);
+        }
+        changeHistory.push({ from: prevDoc, to: doc, timestamp: Date.now() });
+        prevDoc = doc;
+        updateWysiwygStyle();
+      },
+    });
 
-    editable.oninput = () => {
-      const normalized = normalizeText(editable.value);
-      if (editable.value !== normalized) {
-        const selectionStart = editable.selectionStart;
-        editable.value = normalized;
-        // put the cursor at some position close to where it was before
-        // normalization (otherwise it'll end up at the end of the text)
-        editable.selectionStart = selectionStart;
-        editable.selectionEnd = selectionStart;
+    useEffect(() => {
+      if (ed) {
+        editor = ed;
+        if (autoSelect) {
+          ed.commands.focus();
+        }
       }
-      onChange(editable.value);
-    };
-  }
+    }, [ed]);
+
+    return <EditorContent editor={ed} />;
+  };
+
+  const root = createRoot(editable);
+  root.render(<ScratchpadEditor />);
 
   editable.onkeydown = (event) => {
     if (!event.shiftKey && actionZoomIn.keyTest(event)) {
@@ -417,119 +384,10 @@ export const scratchpadWysiwyg = ({
       }
       submittedViaKeyboard = true;
       handleSubmit();
-    } else if (
-      event.key === KEYS.TAB ||
-      (event[KEYS.CTRL_OR_CMD] &&
-        (event.code === CODES.BRACKET_LEFT ||
-          event.code === CODES.BRACKET_RIGHT))
-    ) {
-      event.preventDefault();
-      if (event.isComposing) {
-        return;
-      } else if (event.shiftKey || event.code === CODES.BRACKET_LEFT) {
-        outdent();
-      } else {
-        indent();
-      }
-      // We must send an input event to resize the element
-      editable.dispatchEvent(new Event("input"));
     }
   };
 
-  const TAB_SIZE = 4;
-  const TAB = " ".repeat(TAB_SIZE);
-  const RE_LEADING_TAB = new RegExp(`^ {1,${TAB_SIZE}}`);
-  const indent = () => {
-    const { selectionStart, selectionEnd } = editable;
-    const linesStartIndices = getSelectedLinesStartIndices();
-
-    let value = editable.value;
-    linesStartIndices.forEach((startIndex: number) => {
-      const startValue = value.slice(0, startIndex);
-      const endValue = value.slice(startIndex);
-
-      value = `${startValue}${TAB}${endValue}`;
-    });
-
-    editable.value = value;
-
-    editable.selectionStart = selectionStart + TAB_SIZE;
-    editable.selectionEnd = selectionEnd + TAB_SIZE * linesStartIndices.length;
-  };
-
-  const outdent = () => {
-    const { selectionStart, selectionEnd } = editable;
-    const linesStartIndices = getSelectedLinesStartIndices();
-    const removedTabs: number[] = [];
-
-    let value = editable.value;
-    linesStartIndices.forEach((startIndex) => {
-      const tabMatch = value
-        .slice(startIndex, startIndex + TAB_SIZE)
-        .match(RE_LEADING_TAB);
-
-      if (tabMatch) {
-        const startValue = value.slice(0, startIndex);
-        const endValue = value.slice(startIndex + tabMatch[0].length);
-
-        // Delete a tab from the line
-        value = `${startValue}${endValue}`;
-        removedTabs.push(startIndex);
-      }
-    });
-
-    editable.value = value;
-
-    if (removedTabs.length) {
-      if (selectionStart > removedTabs[removedTabs.length - 1]) {
-        editable.selectionStart = Math.max(
-          selectionStart - TAB_SIZE,
-          removedTabs[removedTabs.length - 1],
-        );
-      } else {
-        // If the cursor is before the first tab removed, ex:
-        // Line| #1
-        //     Line #2
-        // Lin|e #3
-        // we should reset the selectionStart to his initial value.
-        editable.selectionStart = selectionStart;
-      }
-      editable.selectionEnd = Math.max(
-        editable.selectionStart,
-        selectionEnd - TAB_SIZE * removedTabs.length,
-      );
-    }
-  };
-
-  /**
-   * @returns indices of start positions of selected lines, in reverse order
-   */
-  const getSelectedLinesStartIndices = () => {
-    let { selectionStart, selectionEnd, value } = editable;
-
-    // chars before selectionStart on the same line
-    const startOffset = value.slice(0, selectionStart).match(/[^\n]*$/)![0]
-      .length;
-    // put caret at the start of the line
-    selectionStart = selectionStart - startOffset;
-
-    const selected = value.slice(selectionStart, selectionEnd);
-
-    return selected
-      .split("\n")
-      .reduce(
-        (startIndices, line, idx, lines) =>
-          startIndices.concat(
-            idx
-              ? // curr line index is prev line's start + prev line's length + \n
-                startIndices[idx - 1] + lines[idx - 1].length + 1
-              : // first selected line
-                selectionStart,
-          ),
-        [] as number[],
-      )
-      .reverse();
-  };
+  // indentation helpers removed for tiptap editor
 
   const stopEvent = (event: Event) => {
     if (event.target instanceof HTMLCanvasElement) {
@@ -563,7 +421,7 @@ export const scratchpadWysiwyg = ({
     );
 
     if (container) {
-      if (editable.value.trim()) {
+      if (editor?.getText().trim()) {
         const boundTextElementId = getBoundTextElementId(container);
         if (!boundTextElementId || boundTextElementId !== element.id) {
           app.scene.mutateElement(container, {
@@ -592,14 +450,13 @@ export const scratchpadWysiwyg = ({
 
     onSubmit({
       viaKeyboard: submittedViaKeyboard,
-      nextOriginalText: editable.value,
+      nextDoc: prevDoc,
     });
   };
 
   const cleanup = () => {
     // remove events to ensure they don't late-fire
     editable.onblur = null;
-    editable.oninput = null;
     editable.onkeydown = null;
 
     if (observer) {
@@ -615,6 +472,7 @@ export const scratchpadWysiwyg = ({
     unbindUpdate();
     unbindOnScroll();
 
+    root.unmount();
     editable.remove();
   };
 
@@ -635,7 +493,7 @@ export const scratchpadWysiwyg = ({
 
       // case: clicking on the same property → no change → no update → no focus
       if (!isPropertiesTrigger) {
-        editable.focus();
+        editor?.commands.focus();
       }
     });
   };
@@ -702,7 +560,7 @@ export const scratchpadWysiwyg = ({
       ".properties-content",
     );
     if (!isPopupOpened) {
-      editable.focus();
+      editor?.commands.focus();
     }
   });
 
@@ -717,7 +575,7 @@ export const scratchpadWysiwyg = ({
   if (autoSelect) {
     // select on init (focusing is done separately inside the bindBlurEvent()
     // because we need it to happen *after* the blur event from `pointerdown`)
-    editable.select();
+    editor?.commands.selectAll();
   }
   bindBlurEvent();
 


### PR DESCRIPTION
## Summary
- switch scratchpad wysiwyg to use TipTap `useEditor`
- report doc updates via `editor.getJSON`
- keep editor positioning and cleanup logic

## Testing
- `yarn test` *(fails: Tests failed. Watching for file changes...)*

------
https://chatgpt.com/codex/tasks/task_e_6846efe1ff7c832b8899a3e1d09b8c6a