### PR TITLE
Add page component

### DIFF
--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -37,6 +37,8 @@ export const APP_NAME = "Excalidraw";
 export const TEXT_AUTOWRAP_THRESHOLD = 36; // px
 export const DEFAULT_SCRATCHPAD_WIDTH_RATIO = 0.2;
 export const DEFAULT_SCRATCHPAD_HEIGHT_RATIO = 0.15;
+export const DEFAULT_PAGE_WIDTH = 800;
+export const DEFAULT_PAGE_HEIGHT = 600;
 
 export const DRAGGING_THRESHOLD = 10; // px
 export const LINE_CONFIRM_THRESHOLD = 8; // px
@@ -148,7 +150,7 @@ export const FONT_FAMILY = {
   "Comic Shanns": 8,
   "Liberation Sans": 9,
   Assistant: 10,
-  "Arimo": 11
+  Arimo: 11,
 };
 
 export const FONT_FAMILY_FALLBACKS = {
@@ -425,7 +427,8 @@ export const LIBRARY_DISABLED_TYPES = new Set([
   "iframe",
   "embeddable",
   "image",
-  "scratchpad"
+  "scratchpad",
+  "page",
 ] as const);
 
 // use these constants to easily identify reference sites
@@ -447,6 +450,7 @@ export const TOOL_TYPE = {
   embeddable: "embeddable",
   laser: "laser",
   scratchpad: "scratchpad",
+  page: "page",
 } as const;
 
 export const EDITOR_LS_KEYS = {

--- a/packages/element/src/newElement.ts
+++ b/packages/element/src/newElement.ts
@@ -10,9 +10,9 @@ import {
   getFontString,
   getUpdatedTimestamp,
   getLineHeight,
+  DEFAULT_PAGE_WIDTH,
+  DEFAULT_PAGE_HEIGHT,
 } from "@excalidraw/common";
-
-import type { JSONContent } from "@tiptap/core";
 
 import type { Radians } from "@excalidraw/math";
 
@@ -28,6 +28,8 @@ import { normalizeText, measureText } from "./textMeasurements";
 import { wrapText } from "./textWrapping";
 
 import { isLineElement } from "./typeChecks";
+
+import type { JSONContent } from "@tiptap/core";
 
 import type {
   ExcalidrawElement,
@@ -50,7 +52,8 @@ import type {
   ExcalidrawArrowElement,
   ExcalidrawElbowArrowElement,
   ExcalidrawLineElement,
-  ExcalidrawScratchpadElement
+  ExcalidrawScratchpadElement,
+  ExcalidrawPageElement,
 } from "./types";
 
 export type ElementConstructorOpts = MarkOptional<
@@ -253,8 +256,7 @@ export const newScratchpadElement = (
   const fontFamily = opts.fontFamily ?? DEFAULT_FONT_FAMILY;
   const fontSize = opts.fontSize ?? DEFAULT_FONT_SIZE;
 
-  const tiptapDoc: JSONContent =
-    opts.tiptapDoc ?? { type: "doc", content: [] };
+  const tiptapDoc: JSONContent = opts.tiptapDoc ?? { type: "doc", content: [] };
 
   const metrics = measureText(
     "",
@@ -274,7 +276,11 @@ export const newScratchpadElement = (
   }
 
   const scratchpadElementProps: ExcalidrawScratchpadElement = {
-    ..._newElementBase<ExcalidrawScratchpadElement>("scratchpad", {...opts, width, height}),
+    ..._newElementBase<ExcalidrawScratchpadElement>("scratchpad", {
+      ...opts,
+      width,
+      height,
+    }),
     tiptapDoc,
     originalTiptapDoc: tiptapDoc,
     containerId: opts.containerId || null,
@@ -289,8 +295,33 @@ export const newScratchpadElement = (
   return newElementWith(scratchpadElementProps, {});
 };
 
+export const newPageElement = (
+  opts: ElementConstructorOpts & {
+    tiptapDoc?: JSONContent;
+    containerId?: ExcalidrawTextContainer["id"] | null;
+    fontFamily?: FontFamilyValues;
+    fontSize?: number;
+    width?: number;
+    height?: number;
+    margin?: { top: number; right: number; bottom: number; left: number };
+    backgroundImage?: string | null;
+  },
+): NonDeleted<ExcalidrawPageElement> => {
+  const element = newScratchpadElement({
+    ...opts,
+    width: opts.width ?? DEFAULT_PAGE_WIDTH,
+    height: opts.height ?? DEFAULT_PAGE_HEIGHT,
+  }) as ExcalidrawPageElement;
+
+  return newElementWith(element, {
+    type: "page",
+    margin: opts.margin ?? { top: 40, right: 40, bottom: 40, left: 40 },
+    backgroundImage: opts.backgroundImage ?? null,
+  });
+};
+
 // export const newScratchpadElement = (
-//   opts: ElementConstructorOpts & { 
+//   opts: ElementConstructorOpts & {
 //     tiptapDoc?: JSONContent;
 //     containerId?: ExcalidrawTextContainer["id"] | null;
 //   },
@@ -349,7 +380,6 @@ export const newTextElement = (
   const verticalAlign = opts.verticalAlign || DEFAULT_VERTICAL_ALIGN;
   const autoResize = opts.autoResize ?? true;
   const fontString = getFontString({ fontFamily, fontSize });
-  
 
   let width = metrics.width;
   let height = metrics.height;

--- a/packages/element/src/renderElement.ts
+++ b/packages/element/src/renderElement.ts
@@ -59,6 +59,8 @@ import { getCornerRadius } from "./shapes";
 
 import { ShapeCache } from "./ShapeCache";
 
+import { parseTiptapDoc } from "./parseTiptapDoc";
+
 import type {
   ExcalidrawElement,
   ExcalidrawTextElement,
@@ -73,7 +75,6 @@ import type {
 
 import type { StrokeOptions } from "perfect-freehand";
 import type { RoughCanvas } from "roughjs/bin/canvas";
-import { parseTiptapDoc } from "./parseTiptapDoc";
 
 // using a stronger invert (100% vs our regular 93%) and saturate
 // as a temp hack to make images in dark theme look closer to original
@@ -816,7 +817,8 @@ export const renderElement = (
 
       break;
     }
-    case "scratchpad": {
+    case "scratchpad":
+    case "page": {
       // const lines = parseTiptapDoc(element.tiptapDoc);
 
       const lines = parseTiptapDoc(element.tiptapDoc, {
@@ -835,7 +837,7 @@ export const renderElement = (
       context.translate(cx, cy);
       context.rotate(element.angle);
       context.translate(-shiftX, -shiftY); // position at element.x/y
-      
+
       context.textAlign = "left";
       context.textBaseline = "alphabetic";
 
@@ -845,12 +847,19 @@ export const renderElement = (
         let bottomGap = 0;
 
         for (const seg of line) {
-          const lineHeightPx = getLineHeightInPx(seg.fontSize, getLineHeight(seg.fontFamily));
-          const verticalOffset = getVerticalOffset(seg.fontFamily, seg.fontSize, lineHeightPx);
+          const lineHeightPx = getLineHeightInPx(
+            seg.fontSize,
+            getLineHeight(seg.fontFamily),
+          );
+          const verticalOffset = getVerticalOffset(
+            seg.fontFamily,
+            seg.fontSize,
+            lineHeightPx,
+          );
           baselineOffset = Math.max(baselineOffset, verticalOffset);
           bottomGap = Math.max(bottomGap, lineHeightPx - verticalOffset);
         }
-        
+
         let cursorX = 0;
         // let lineHeight = 0;
         for (const seg of line) {
@@ -862,8 +871,12 @@ export const renderElement = (
           });
           context.font = fontString;
           context.fillStyle = seg.color;
-          context.fillText(seg.text, cursorX, cursorY+baselineOffset);
-          const metrics = measureText(seg.text, fontString, getLineHeight(seg.fontFamily));
+          context.fillText(seg.text, cursorX, cursorY + baselineOffset);
+          const metrics = measureText(
+            seg.text,
+            fontString,
+            getLineHeight(seg.fontFamily),
+          );
           if (seg.strike) {
             const strikeY = cursorY + baselineOffset - seg.fontSize * 0.3;
             context.beginPath();

--- a/packages/element/src/shapes.ts
+++ b/packages/element/src/shapes.ts
@@ -64,6 +64,7 @@ export const getElementShape = <Point extends GlobalPoint | LocalPoint>(
     case "iframe":
     case "text":
     case "scratchpad":
+    case "page":
     case "selection":
       return getPolygonShape(element);
     case "arrow":
@@ -100,8 +101,6 @@ export const getElementShape = <Point extends GlobalPoint | LocalPoint>(
         shouldTestInside(element),
       );
     }
-    
-
   }
 };
 

--- a/packages/element/src/typeChecks.ts
+++ b/packages/element/src/typeChecks.ts
@@ -33,6 +33,7 @@ import type {
   ExcalidrawFlowchartNodeElement,
   ExcalidrawLinearElementSubType,
   ExcalidrawScratchpadElement,
+  ExcalidrawPageElement,
 } from "./types";
 
 export const isInitializedImageElement = (
@@ -70,7 +71,12 @@ export const isIframeLikeElement = (
 export const isScratchpadElement = (
   element: ExcalidrawElement | null,
 ): element is ExcalidrawScratchpadElement =>
-  element != null && element.type === "scratchpad";
+  element != null && (element.type === "scratchpad" || element.type === "page");
+
+export const isPageElement = (
+  element: ExcalidrawElement | null,
+): element is ExcalidrawPageElement =>
+  element != null && element.type === "page";
 
 export const isTextElement = (
   element: ExcalidrawElement | null,
@@ -262,6 +268,7 @@ export const isExcalidrawElement = (
     case "magicframe":
     case "image":
     case "scratchpad":
+    case "page":
     case "selection": {
       return true;
     }

--- a/packages/element/src/types.ts
+++ b/packages/element/src/types.ts
@@ -1,5 +1,4 @@
 import type { LocalPoint, Radians } from "@excalidraw/math";
-import type { JSONContent } from "@tiptap/core";
 
 import type {
   FONT_FAMILY,
@@ -15,6 +14,8 @@ import type {
   Merge,
   ValueOf,
 } from "@excalidraw/common/utility-types";
+
+import type { JSONContent } from "@tiptap/core";
 
 export type ChartType = "bar" | "line";
 export type FillStyle = "hachure" | "cross-hatch" | "solid" | "zigzag";
@@ -215,6 +216,7 @@ export type ExcalidrawElement =
   | ExcalidrawIframeElement
   | ExcalidrawEmbeddableElement
   | ExcalidrawScratchpadElement
+  | ExcalidrawPageElement;
 
 export type ExcalidrawNonSelectionElement = Exclude<
   ExcalidrawElement,
@@ -222,25 +224,33 @@ export type ExcalidrawNonSelectionElement = Exclude<
 >;
 
 export interface ChangeEntry {
-  from: JSONContent;    // previous state of the edited fragment
-  to: JSONContent;      // new state after the edit
-  timestamp: number;    // Unix epoch or Date.now()
-  approved?: boolean;   // mark when a reviewer accepts the change
+  from: JSONContent; // previous state of the edited fragment
+  to: JSONContent; // new state after the edit
+  timestamp: number; // Unix epoch or Date.now()
+  approved?: boolean; // mark when a reviewer accepts the change
 }
 
-export type ExcalidrawScratchpadElement = _ExcalidrawElementBase & Readonly<{
-  type: "scratchpad";
-  // Tiptap’s JSON document representing the rich text
-  tiptapDoc: JSONContent;
-  originalTiptapDoc: JSONContent;  // source doc used when rewrapping
-  // optional history of edits if change‑tracking will be implemented
-  changeHistory?: ChangeEntry[];
+export type ExcalidrawScratchpadElement = _ExcalidrawElementBase &
+  Readonly<{
+    type: "scratchpad";
+    // Tiptap’s JSON document representing the rich text
+    tiptapDoc: JSONContent;
+    originalTiptapDoc: JSONContent; // source doc used when rewrapping
+    // optional history of edits if change‑tracking will be implemented
+    changeHistory?: ChangeEntry[];
 
-  containerId: ExcalidrawGenericElement["id"] | null;
-  autoResize: boolean;             // new property
-  fontFamily: FontFamilyValues;
-  fontSize: number;
-}>;
+    containerId: ExcalidrawGenericElement["id"] | null;
+    autoResize: boolean; // new property
+    fontFamily: FontFamilyValues;
+    fontSize: number;
+  }>;
+
+export type ExcalidrawPageElement = ExcalidrawScratchpadElement &
+  Readonly<{
+    type: "page";
+    margin: { top: number; right: number; bottom: number; left: number };
+    backgroundImage: string | null;
+  }>;
 
 export type Ordered<TElement extends ExcalidrawElement> = TElement & {
   index: FractionalIndex;

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -104,6 +104,8 @@ import {
   Emitter,
   DEFAULT_SCRATCHPAD_WIDTH_RATIO,
   DEFAULT_SCRATCHPAD_HEIGHT_RATIO,
+  DEFAULT_PAGE_WIDTH,
+  DEFAULT_PAGE_HEIGHT,
 } from "@excalidraw/common";
 
 import { getCommonBounds, getElementAbsoluteCoords } from "@excalidraw/element";
@@ -136,6 +138,7 @@ import {
   newTextElement,
   refreshTextDimensions,
   newScratchpadElement,
+  newPageElement,
 } from "@excalidraw/element";
 
 import { deepCopyElement, duplicateElements } from "@excalidraw/element";
@@ -162,6 +165,7 @@ import {
   isBindableElement,
   isTextElement,
   isScratchpadElement,
+  isPageElement,
 } from "@excalidraw/element";
 
 import {
@@ -296,6 +300,12 @@ import { Scene } from "@excalidraw/element";
 
 import { Store, CaptureUpdateAction } from "@excalidraw/element";
 
+import {
+  measureTiptapDoc,
+  measureTiptapDocWithWidth,
+  wrapTiptapDoc,
+} from "@excalidraw/element/parseTiptapDoc";
+
 import type { ElementUpdate } from "@excalidraw/element";
 
 import type { LocalPoint, Radians } from "@excalidraw/math";
@@ -326,6 +336,7 @@ import type {
   ExcalidrawElbowArrowElement,
   SceneElementsMap,
   ExcalidrawScratchpadElement,
+  ExcalidrawPageElement,
 } from "@excalidraw/element/types";
 
 import type { Mutable, ValueOf } from "@excalidraw/common/utility-types";
@@ -534,7 +545,6 @@ import type {
 } from "../types";
 import type { RoughCanvas } from "roughjs/bin/canvas";
 import type { Action, ActionResult } from "../actions/types";
-import { measureTiptapDoc, measureTiptapDocWithWidth, wrapTiptapDoc } from "@excalidraw/element/parseTiptapDoc";
 
 const AppContext = React.createContext<AppClassProperties>(null!);
 const AppPropsContext = React.createContext<AppProps>(null!);
@@ -5100,7 +5110,11 @@ class App extends React.Component<AppProps, AppState> {
     //   );
     // };
 
-    const updateElement = (nextDoc: JSONContent, isDeleted: boolean, wrapDoc: boolean) => {
+    const updateElement = (
+      nextDoc: JSONContent,
+      isDeleted: boolean,
+      wrapDoc: boolean,
+    ) => {
       let width = element.width;
       let height: number;
       let doc = nextDoc;
@@ -5209,14 +5223,18 @@ class App extends React.Component<AppProps, AppState> {
     const element = this.getElementAtPosition(x, y, {
       includeBoundTextElement: true,
     });
-    
+
     // if (element && isTextElement(element) && !element.isDeleted) {
     //   return element;
     // }
     // return null;
 
-    return element && (isTextElement(element) || isScratchpadElement(element)) && !element.isDeleted
-      ? (element as NonDeleted<ExcalidrawTextElement | ExcalidrawScratchpadElement>)
+    return element &&
+      (isTextElement(element) || isScratchpadElement(element)) &&
+      !element.isDeleted
+      ? (element as NonDeleted<
+          ExcalidrawTextElement | ExcalidrawScratchpadElement
+        >)
       : null;
   }
 
@@ -5461,9 +5479,7 @@ class App extends React.Component<AppProps, AppState> {
         shouldBindToContainer = true;
       }
     }
-    let existingTextElement: NonDeleted<ExcalidrawTextElement>
-        | null =
-      null;
+    let existingTextElement: NonDeleted<ExcalidrawTextElement> | null = null;
 
     const selectedElements = this.scene.getSelectedElements(this.state);
 
@@ -5491,19 +5507,17 @@ class App extends React.Component<AppProps, AppState> {
       }
     }
 
-
     const fontFamily = isTextElement(existingTextElement)
       ? existingTextElement.fontFamily
       : this.state.currentItemFontFamily;
     // const fontFamily =
     //   existingTextElement?.fontFamily || this.state.currentItemFontFamily;
-    
+
     const lineHeight = isTextElement(existingTextElement)
       ? existingTextElement.lineHeight
       : getLineHeight(fontFamily);
     // const lineHeight =
     //   existingTextElement?.lineHeight || getLineHeight(fontFamily);
-    const fontSize = this.state.currentItemFontSize;
 
     if (
       !existingTextElement &&
@@ -5595,9 +5609,9 @@ class App extends React.Component<AppProps, AppState> {
     }
 
     if (autoEdit || existingTextElement || container) {
-        this.handleTextWysiwyg(element, {
-          isExistingElement: !!existingTextElement,
-        });
+      this.handleTextWysiwyg(element, {
+        isExistingElement: !!existingTextElement,
+      });
     } else {
       this.setState({
         newElement: element,
@@ -5675,7 +5689,6 @@ class App extends React.Component<AppProps, AppState> {
 
     // const lineHeight =
     //   existingTextElement?.lineHeight || getLineHeight(fontFamily);
-    const fontSize = this.state.currentItemFontSize;
 
     if (
       !existingTextElement &&
@@ -5718,7 +5731,6 @@ class App extends React.Component<AppProps, AppState> {
     const defaultWidth = this.state.width * DEFAULT_SCRATCHPAD_WIDTH_RATIO;
     const defaultHeight = this.state.height * DEFAULT_SCRATCHPAD_HEIGHT_RATIO;
 
-
     const element =
       existingTextElement ||
       newScratchpadElement({
@@ -5750,6 +5762,149 @@ class App extends React.Component<AppProps, AppState> {
       this.scene.mutateElement(container, {
         boundElements: (container.boundElements || []).concat({
           type: "scratchpad",
+          id: element.id,
+        }),
+      });
+    }
+    this.setState({ editingTextElement: element });
+
+    if (!existingTextElement) {
+      if (container && shouldBindToContainer) {
+        const containerIndex = this.scene.getElementIndex(container.id);
+        this.scene.insertElementAtIndex(element, containerIndex + 1);
+      } else {
+        this.scene.insertElement(element);
+      }
+    }
+
+    if (autoEdit || existingTextElement || container) {
+      this.handleScratchpadWysiwyg(element, {
+        isExistingElement: !!existingTextElement,
+      });
+    } else {
+      this.setState({
+        newElement: element,
+        multiElement: null,
+      });
+    }
+  };
+
+  private startPageEditing = ({
+    sceneX,
+    sceneY,
+    insertAtParentCenter = true,
+    container,
+    autoEdit = true,
+  }: {
+    sceneX: number;
+    sceneY: number;
+    insertAtParentCenter?: boolean;
+    container?: ExcalidrawTextContainer | null;
+    autoEdit?: boolean;
+  }) => {
+    let shouldBindToContainer = false;
+
+    let parentCenterPosition =
+      insertAtParentCenter &&
+      this.getTextWysiwygSnappedToCenterPosition(
+        sceneX,
+        sceneY,
+        this.state,
+        container,
+      );
+    if (container && parentCenterPosition) {
+      const boundTextElementToContainer = getBoundTextElement(
+        container,
+        this.scene.getNonDeletedElementsMap(),
+      );
+      if (!boundTextElementToContainer) {
+        shouldBindToContainer = true;
+      }
+    }
+    let existingTextElement: NonDeleted<ExcalidrawPageElement> | null = null;
+
+    const selectedElements = this.scene.getSelectedElements(this.state);
+
+    if (selectedElements.length === 1) {
+      if (isPageElement(selectedElements[0])) {
+        existingTextElement =
+          selectedElements[0] as NonDeleted<ExcalidrawPageElement>;
+      } else if (container) {
+        const bound = getBoundTextElement(
+          selectedElements[0],
+          this.scene.getNonDeletedElementsMap(),
+        );
+        if (bound && isPageElement(bound)) {
+          existingTextElement = bound as NonDeleted<ExcalidrawPageElement>;
+        }
+      } else {
+        const el = this.getTextElementAtPosition(sceneX, sceneY);
+        if (el && isPageElement(el)) {
+          existingTextElement = el as NonDeleted<ExcalidrawPageElement>;
+        }
+      }
+    } else {
+      const el = this.getTextElementAtPosition(sceneX, sceneY);
+      if (el && isPageElement(el)) {
+        existingTextElement = el as NonDeleted<ExcalidrawPageElement>;
+      }
+    }
+
+    if (
+      !existingTextElement &&
+      shouldBindToContainer &&
+      container &&
+      !isArrowElement(container)
+    ) {
+      if (parentCenterPosition) {
+        parentCenterPosition = this.getTextWysiwygSnappedToCenterPosition(
+          sceneX,
+          sceneY,
+          this.state,
+          container,
+        );
+      }
+    }
+
+    const topLayerFrame = this.getTopLayerFrameAtSceneCoords({
+      x: sceneX,
+      y: sceneY,
+    });
+
+    const defaultWidth = DEFAULT_PAGE_WIDTH;
+    const defaultHeight = DEFAULT_PAGE_HEIGHT;
+
+    const element =
+      existingTextElement ||
+      newPageElement({
+        x: parentCenterPosition ? parentCenterPosition.elementCenterX : sceneX,
+        y: parentCenterPosition ? parentCenterPosition.elementCenterY : sceneY,
+        width: defaultWidth,
+        height: defaultHeight,
+        strokeColor: this.state.currentItemStrokeColor,
+        backgroundColor: this.state.currentItemBackgroundColor,
+        fillStyle: this.state.currentItemFillStyle,
+        strokeWidth: this.state.currentItemStrokeWidth,
+        strokeStyle: this.state.currentItemStrokeStyle,
+        roughness: this.state.currentItemRoughness,
+        opacity: this.state.currentItemOpacity,
+        tiptapDoc: { type: "doc", content: [] },
+        fontFamily: this.state.currentItemFontFamily,
+        fontSize: this.state.currentItemFontSize,
+        containerId: shouldBindToContainer ? container?.id : undefined,
+        groupIds: container?.groupIds ?? [],
+        angle: container
+          ? isArrowElement(container)
+            ? (0 as Radians)
+            : container.angle
+          : (0 as Radians),
+        frameId: topLayerFrame ? topLayerFrame.id : null,
+      });
+
+    if (!existingTextElement && shouldBindToContainer && container) {
+      this.scene.mutateElement(container, {
+        boundElements: (container.boundElements || []).concat({
+          type: "page",
           id: element.id,
         }),
       });
@@ -6961,7 +7116,8 @@ class App extends React.Component<AppProps, AppState> {
       this.state.activeTool.type === "selection" ||
       this.state.activeTool.type === "lasso" ||
       this.state.activeTool.type === "text" ||
-      this.state.activeTool.type === "scratchpad" || // new condition
+      this.state.activeTool.type === "scratchpad" ||
+      this.state.activeTool.type === "page" ||
       this.state.activeTool.type === "image";
 
     if (!allowOnPointerDown) {
@@ -6976,6 +7132,8 @@ class App extends React.Component<AppProps, AppState> {
       );
     } else if (this.state.activeTool.type === "scratchpad") {
       this.handleScratchpadOnPointerDown(event, pointerDownState);
+    } else if (this.state.activeTool.type === "page") {
+      this.handlePageOnPointerDown(event, pointerDownState);
     } else if (this.state.activeTool.type === "text") {
       this.handleTextOnPointerDown(event, pointerDownState);
     } else if (
@@ -7918,6 +8076,43 @@ class App extends React.Component<AppProps, AppState> {
       sceneY = element.y + element.height / 2;
     }
     this.startScratchpadEditing({
+      sceneX,
+      sceneY,
+      insertAtParentCenter: !event.altKey,
+      container,
+      autoEdit: false,
+    });
+
+    resetCursor(this.interactiveCanvas);
+    if (!this.state.activeTool.locked) {
+      this.setState({
+        activeTool: updateActiveTool(this.state, { type: "selection" }),
+      });
+    }
+  };
+
+  private handlePageOnPointerDown = (
+    event: React.PointerEvent<HTMLElement>,
+    pointerDownState: PointerDownState,
+  ): void => {
+    if (this.state.editingTextElement) {
+      return;
+    }
+    let sceneX = pointerDownState.origin.x;
+    let sceneY = pointerDownState.origin.y;
+
+    const element = this.getElementAtPosition(sceneX, sceneY, {
+      includeBoundTextElement: true,
+    });
+
+    let container = this.getTextBindableContainerAtPosition(sceneX, sceneY);
+
+    if (hasBoundTextElement(element)) {
+      container = element as ExcalidrawTextContainer;
+      sceneX = element.x + element.width / 2;
+      sceneY = element.y + element.height / 2;
+    }
+    this.startPageEditing({
       sceneX,
       sceneY,
       insertAtParentCenter: !event.altKey,
@@ -9675,8 +9870,7 @@ class App extends React.Component<AppProps, AppState> {
         this.handleTextWysiwyg(newElement, {
           isExistingElement: true,
         });
-      }
-      else if (isScratchpadElement(newElement)) {
+      } else if (isScratchpadElement(newElement)) {
         this.resetCursor();
         this.handleScratchpadWysiwyg(newElement, { isExistingElement: true });
       }

--- a/packages/excalidraw/components/icons.tsx
+++ b/packages/excalidraw/components/icons.tsx
@@ -350,13 +350,27 @@ export const ScratchpadIcon = createIcon(
     strokeLinejoin="round"
     stroke="currentColor"
   >
-    <path d="M5 3m0 2a2 2 0 0 1 2 -2h10a2 2 0 0 1 2 2v14a2 2 0 0 1 -2 2h-10a2 2 0 0 1 -2 -2z" /><path d="M9 7l6 0" /><path d="M9 11l6 0" /><path d="M9 15l4 0" />
+    <path d="M5 3m0 2a2 2 0 0 1 2 -2h10a2 2 0 0 1 2 2v14a2 2 0 0 1 -2 2h-10a2 2 0 0 1 -2 -2z" />
+    <path d="M9 7l6 0" />
+    <path d="M9 11l6 0" />
+    <path d="M9 15l4 0" />
   </g>,
-  tablerIconProps
-)
+  tablerIconProps,
+);
 
+export const PageIcon = createIcon(
+  <g
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    stroke="currentColor"
+  >
+    <path d="M4 4h12l4 4v12H4z" />
+    <path d="M16 4v4h4" />
+  </g>,
+  tablerIconProps,
+);
 
- 
 // tabler-icons: arrow-narrow-right
 export const ArrowIcon = createIcon(
   <g strokeWidth="1.5">

--- a/packages/excalidraw/components/shapes.tsx
+++ b/packages/excalidraw/components/shapes.tsx
@@ -6,12 +6,13 @@ import {
   ArrowIcon,
   TextIcon,
   ScratchpadIcon,
+  PageIcon,
   DiamondIcon,
   EllipseIcon,
   LineIcon,
   FreedrawIcon,
   ImageIcon,
-  EraserIcon
+  EraserIcon,
 } from "./icons";
 
 export const SHAPES = [
@@ -90,6 +91,13 @@ export const SHAPES = [
     value: "scratchpad",
     key: KEYS.S, // choose an appropriate shortcut
     numericKey: KEYS["3"], // adjust if another number is free
+    fillable: false,
+  },
+  {
+    icon: PageIcon,
+    value: "page",
+    key: KEYS.G,
+    numericKey: null,
     fillable: false,
   },
 ] as const;

--- a/packages/excalidraw/data/restore.ts
+++ b/packages/excalidraw/data/restore.ts
@@ -91,6 +91,7 @@ export const AllowedExcalidrawActiveTools: Record<
   lasso: true,
   text: true,
   scratchpad: true,
+  page: true,
   rectangle: true,
   diamond: true,
   ellipse: true,

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -277,7 +277,8 @@
       "embeddable": "Embeddable elements cannot be added to the library.",
       "iframe": "IFrame elements cannot be added to the library.",
       "image": "Support for adding images to the library coming soon!",
-      "scratchpad": "Support for adding scratchpads to the library coming soon!"
+      "scratchpad": "Support for adding scratchpads to the library coming soon!",
+      "page": "Support for adding pages to the library coming soon!"
     },
     "asyncPasteFailedOnRead": "Couldn't paste (couldn't read from system clipboard).",
     "asyncPasteFailedOnParse": "Couldn't paste.",
@@ -307,7 +308,8 @@
     "extraTools": "More tools",
     "mermaidToExcalidraw": "Mermaid to Excalidraw",
     "convertElementType": "Toggle shape type",
-    "scratchpad": "Scratchpad"
+    "scratchpad": "Scratchpad",
+    "page": "Page"
   },
   "element": {
     "rectangle": "Rectangle",
@@ -324,7 +326,8 @@
     "embeddable": "Web Embed",
     "selection": "Selection",
     "iframe": "IFrame",
-    "scratchpad": "Scratchpad"
+    "scratchpad": "Scratchpad",
+    "page": "Page"
   },
   "headings": {
     "canvasActions": "Canvas actions",

--- a/packages/excalidraw/types.ts
+++ b/packages/excalidraw/types.ts
@@ -156,6 +156,7 @@ export type ToolType =
   | "magicframe"
   | "embeddable"
   | "scratchpad"
+  | "page"
   | "laser";
 
 export type ElementOrToolType = ExcalidrawElementType | ToolType | "custom";


### PR DESCRIPTION
## Summary
- add page element type built on scratchpad
- add constants and icon for page
- support page tool in app and shapes menu
- update locale text

## Testing
- `yarn fix` *(fails: ESLint warnings)*
- `yarn test:typecheck` *(fails: TypeScript errors)*
- `yarn test:update` *(fails: test errors)*

------
https://chatgpt.com/codex/tasks/task_e_6852f1892bb8832b86f6679ab2c6071d